### PR TITLE
Introduce routing at app level.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7365,6 +7365,11 @@
         "react-is": "^16.7.0"
       }
     },
+    "hookrouter": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/hookrouter/-/hookrouter-1.2.5.tgz",
+      "integrity": "sha512-9OLve2u+JZDCOgPnxJu5dvg/mU1w2ZWWlSOFxCKcGQKRSH1MXI8tMwEgm64mQfjZLET/7yFRTUrZ4hUYoK0ezw=="
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "hookrouter": "^1.2.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,15 @@
 import './App.css';
-import { GoNextLayout } from './components/GoNextLayout';
+import { LandingPageLayout } from './components/LandingPageLayout';
+import {useRoutes} from 'hookrouter';
 
 function App() {
+  const routes = {
+    '/' :()=><LandingPageLayout/>,
+  };
+  const routeResults = useRoutes(routes);
   return (
     <div className="App">
-      <GoNextLayout />
+      {routeResults}
     </div>
   );
 }

--- a/src/components/LandingPageLayout.js
+++ b/src/components/LandingPageLayout.js
@@ -2,7 +2,7 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { TextField } from '@material-ui/core';
 import games from '../data/games.json';
 
-export function GoNextLayout() {
+export function LandingPageLayout() {
     const searchBar =
     (<Autocomplete
         id='game-search-bar'
@@ -11,12 +11,11 @@ export function GoNextLayout() {
         renderInput={(params) => <TextField {...params} label="Combo box" variant="outlined" />}
     />);
 
-
     // return the constructed layout for the App to show the user
     return (<>
         {searchBar}
         <p>
-            This is the <code>src/components/GoNextLayout.js</code> layout component.
+            This is the <code>src/components/LandingPageLayout.js</code> component.
         </p>
         <div className='welcome-text'>
             <p>Welcome to Go Next!</p>


### PR DESCRIPTION
This PR introduces the hookrouter package as a simple means of handling page navigation within the app. This also renames the layout component to LandingPageLayout to establish a better naming convention as we prepare for additional pages in the future.