### PR TITLE
Include Pokemon BDSP.

### DIFF
--- a/src/data/games.json
+++ b/src/data/games.json
@@ -26,5 +26,9 @@
     {
         "title": "Getting Over It with Bennett Foddy",
         "platforms": [ "PC", "Google Play" ]
+    },
+    {
+        "title": "Pokemon Brilliant Diamond/Shining Pearl",
+        "platforms": ["Nintendo Switch"]
     }
 ]


### PR DESCRIPTION
I added Pokemon Brilliant Diamond/Shining Pearl to our game list. The game is currently only available on Switch.